### PR TITLE
fix: lefthookのbiomeチェックに警告時のエラーオプションを追加

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
     type-check:
       run: bun run tsc
     biome-check:
-      run: bunx biome check --write --files-ignore-unknown=true --no-errors-on-unmatched {staged_files}
+      run: bunx biome check --write --files-ignore-unknown=true --no-errors-on-unmatched --error-on-warnings {staged_files}
       stage_fixed: true
 
 pre-push:


### PR DESCRIPTION
## 概要
Lefthookのpre-commitフックでBiomeの警告もエラーとして扱うように設定を追加しました。

## 変更内容
- にオプションを追加
- これにより、コード品質の維持がより厳密になります

## 影響
- 警告レベルの問題もコミット時にブロックされるようになります
- より高品質なコードの維持が可能になります